### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Table View Pager for iOS
 ====================
 
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/TableViewPager.svg)](https://img.shields.io/cocoapods/v/TableViewPager.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/TableViewPager.svg)](https://img.shields.io/cocoapods/v/TableViewPager.svg)
 [![Platform](https://img.shields.io/cocoapods/p/TableViewPager.svg?style=flat)](http://cocoadocs.org/docsets/TableViewPager)
 
 A simple 'Table View Pager' for iOS which is inspired by Android's view pager. It is useful for applications having requirement of multiple table views which requires switching with the help of different tabs in one ViewController.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
